### PR TITLE
createFriendStream: re-emit contacts when hop value changes

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,20 @@ function isFriend (friends, a, b) {
   return friends[a] && friends[b] && friends[a][b] && friends[b][a]
 }
 
+function checkHopsUpdated (then, now) {
+  return then[0] !== now[0]
+}
+
+var algOpts = {
+  initial: block.initial,
+  compare: block.compare,
+  update: function (then, now) {
+    return block.update(then, now) || checkHopsUpdated(then, now)
+  },
+  reduce: block.reduce,
+  expand: block.expand
+}
+
 exports.name = 'friends'
 exports.version = '1.0.0'
 exports.manifest = {
@@ -80,15 +94,15 @@ exports.init = function (sbot, config) {
 
         //the edge has already been added to g
         if(!reachable) {
-          reachable = F.reachable(g, start, block)
+          reachable = F.reachable(g, start, algOpts)
           reachable[sbot.id] = [0, undefined]
           for(var k in reachable)
             if(block.isWanted(reachable[k]))
               push(k, reachable[k][0])
         } else {
-          var _reachable = F.reachable(g, start, block)
+          var _reachable = F.reachable(g, start, algOpts)
           _reachable[sbot.id] = [0, undefined]
-          var patch = F.diff(reachable, _reachable, block)
+          var patch = F.diff(reachable, _reachable, algOpts)
           for(var k in patch) {
             if(patch[k] == null || patch[k][0] == null || patch[k][0] > patch[k][1])
               push(k, -1)
@@ -200,7 +214,3 @@ exports.init = function (sbot, config) {
     }
   }
 }
-
-
-
-

--- a/test/hops.js
+++ b/test/hops.js
@@ -1,0 +1,49 @@
+var pull = require('pull-stream')
+var tape = require('tape')
+var createSbot = require('scuttlebot')
+  .use(require('scuttlebot/plugins/replicate'))
+  .use(require('../'))
+
+  var a_bot = createSbot({
+    temp: 'alice',
+    port: 45451, host: 'localhost', timeout: 20001,
+    replicate: {hops: 2, legacy: false},
+//    keys: alice
+  })
+
+tape('check that friends are re-emitted when distance changes when `hops: 2`', function (t) {
+
+  var changes = []
+
+  pull(
+    a_bot.friends.createFriendStream({live: true, meta: true, hops: 2}),
+    pull.drain(function (m) { changes.push(m) })
+  )
+
+  var followFeed = a_bot.createFeed()
+  var foafFeed = a_bot.createFeed()
+
+  followFeed.publish({
+    type: 'contact',
+    contact: foafFeed.id,
+    following: true
+  }, function () {
+    t.deepEqual(changes, [
+      { id: a_bot.id, hops: 0 }
+    ])
+
+    a_bot.publish({
+      type: 'contact',
+      contact: followFeed.id,
+      following: true
+    }, function () {
+      t.deepEqual(changes, [
+        { id: a_bot.id, hops: 0 },
+        { id: followFeed.id, hops: 1 },
+        { id: foafFeed.id, hops: 2 }
+      ])
+      a_bot.close()
+      t.end()
+    })
+  })
+})

--- a/test/sbot.js
+++ b/test/sbot.js
@@ -44,11 +44,10 @@ tape('live follows works', function (t) {
     pull.drain(function (m) { c.push(m) })
   )
 
-
   gen.initialize(a_bot, 10, 1, function (err, peers) {
     console.log(peers.map(function (e) { return e.id }))
     console.log(a)
-    t.deepEqual(a.length, peers.length)
+    // t.deepEqual(a.length, peers.length) // is this test still important?
     b.forEach(function (e) { t.ok(e.hops <= 1, 'b '+e.hops+' hops <= 1') })
     c.forEach(function (e) { t.ok(e.hops <= 2, 'c '+e.hops+' hops <= 2') })
     t.ok(a.length >= b.length)
@@ -59,4 +58,3 @@ tape('live follows works', function (t) {
   })
 
 })
-


### PR DESCRIPTION
It is possible to have contacts that we know about without them being inside of the hop distance. If a change to the graph causes them to fall within the distance, they are not being emitted.

This means that in some cases (particularly when `hops == 2`), we won't know to replicate with someone that has now become a FOAF until sbot is restarted.

**The PR fixes this problem by re-emitting contacts whenever the hop value changes.** Also added tests to check that this is working (`test/hops.js` fails without this PR). 

Had to remove [a check from another test](https://github.com/ssbc/ssb-friends/blob/1fecb6365f8de960e8bc11af5d7e6e8ae80705c0/test/sbot.js#L50) that verified that the total amount of contact messages emitted matched the number of contacts. Because we are emitting messages as we learn about the graph and since the test uses random connections, this is no longer deterministic.

fixes #4

cc @dominictarr 

### failing test case

- configure sbot to only do 2 hops
- with a fresh feed, follow a friend that is on the local network (already automatically replicated): _we download all of their friends-of-friends as expected_
- follow someone that they follow: _we don't download any new messages (but we should)_
- restarting the client will then cause the missing messages to be downloaded (since all of the hops are re-emitted)

---

Potentially it could be a problem that we re-emit contacts whenever their distance changes. But in every case that I can currently think of, this is the desired behavior.