### PR TITLE
Hotfix: Disable F.diffReachable

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,13 +90,13 @@ exports.init = function (sbot, config) {
             if(block.isWanted(reachable[k]))
               push(k, reachable[k][0])
         }
-        else if(v.value) { //follows can be calculated cheaply!
-          var patch = F.diffReachable(g, reachable, v, block)
-          for(var k in patch) {
-            reachable[k] = patch[k]
-            push(k, patch[k][0])
-          }
-        }
+        // else if(v.value) { //follows can be calculated cheaply!
+        //   var patch = F.diffReachable(g, reachable, v, block)
+        //   for(var k in patch) {
+        //     reachable[k] = patch[k]
+        //     push(k, patch[k][0])
+        //   }
+        // }
         else {
           var _reachable = F.reachable(g, start, block)
           _reachable[sbot.id] = [0, undefined]


### PR DESCRIPTION
There are some cases where `F.diffReachable` returns a value `null` which in turn throws
```
TypeError: Cannot read property '0' of null
index.js:97
            push(k, patch[k][0])
```