### PR TITLE
don't change following/blocking value unless the key is actually specified

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,6 +31,19 @@ function isEmpty (o) {
   return true
 }
 
+function isGraphChanger (msg) {
+  var c = msg.value.content
+  return c && (
+    typeof c.following === 'boolean' ||
+    typeof c.blocking === 'boolean' ||
+    typeof c.flagged === 'boolean'
+  )
+}
+
+function isContactMsg (msg) {
+  return msg.value.content.type === 'contact' && ref.isFeed(msg.value.content.contact)
+}
+
 exports.name = 'friends'
 exports.version = '1.0.0'
 exports.manifest = {
@@ -49,7 +62,7 @@ exports.init = function (sbot, config) {
     G.addEdge(g, rel.from, rel.to, rel.value)
     return g
   }, function (data) {
-    if(data.value.content.type === 'contact' && ref.isFeed(data.value.content.contact)) {
+    if(isContactMsg(data) && isGraphChanger(data)) {
       var tristate = (
         data.value.content.following ? true
       : data.value.content.flagged || data.value.content.blocking ? false
@@ -225,4 +238,3 @@ exports.init = function (sbot, config) {
     }
   }
 }
-

--- a/test/non-follow-messages.js
+++ b/test/non-follow-messages.js
@@ -1,0 +1,56 @@
+var pull = require('pull-stream')
+var tape = require('tape')
+var createSbot = require('scuttlebot')
+  .use(require('scuttlebot/plugins/replicate'))
+  .use(require('../'))
+
+  var a_bot = createSbot({
+    temp: 'alice',
+    port: 45451, host: 'localhost', timeout: 20001,
+    replicate: {hops: 2, legacy: false},
+//    keys: alice
+  })
+
+tape('check that messages without a following or blocking key are ignored', function (t) {
+  var changes = []
+
+  pull(
+    a_bot.friends.createFriendStream({live: true, meta: true, hops: 2}),
+    pull.drain(function (m) { changes.push(m) })
+  )
+
+  var feedB = a_bot.createFeed()
+
+  // feedA -> feedB
+  a_bot.publish({
+    type: 'contact',
+    contact: feedB.id,
+    following: true
+  }, function () {
+    t.deepEqual(changes, [
+      { id: a_bot.id, hops: 0 },
+      { id: feedB.id, hops: 1 }
+    ])
+
+    changes.length = 0
+
+    a_bot.publish({
+      type: 'contact',
+      contact: feedB.id,
+      sameAs: true
+    }, function () {
+      t.deepEqual(changes, [])
+
+      a_bot.publish({
+        type: 'contact',
+        contact: feedB.id,
+        blocking: true
+      }, function () {
+        t.deepEqual(changes, [
+          { id: feedB.id, hops: -1 }
+        ])
+        t.end()
+      })
+    })
+  })
+})


### PR DESCRIPTION
✅  **Backwards compatible change** 
(unless there is some client that is depending on this bug for unfollowing 😢 although unfollowing is rare, so even if so, wouldn't cause any great grief)

Currently, if a `contact` message without a following key is added, `ssb-friends` will treat this as unfollowing.

This behaviour is not consistent with the way that other **key -> value** types in ssb work. For example, creating an empty `about` message will not remove someone's name/image. Or creating a message with just an image won't remove their name.

This should also be the case with `contact` messages. We should require an explicit `following: false` in order to unfollow someone. 

`contact` should be able to express relationships (such as `sameAs` or `owner`) and it can't do this in a nice way right now unless you hack on a `following: lastValue` to every message. **This causes problems in clients because they see `following: true` and assume that that means this should be rendered as a following message  though that value has not changed.** IMO the value should ONLY be specified if that value has changed.

Let's nip this in the bud while ssb is still young and there aren't that many clients in the wild!

fixes https://github.com/ssbc/ssb-friends/issues/8

@dominictarr @clehner @mixmix @ahdinosaur @evbogue 