### PR TITLE
Pass priority to request.

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,7 +117,7 @@ exports.init = function (sbot, config) {
     pull.drain(function (data) {
       if(data.sync) return
       for(var k in data) {
-        sbot.replicate.request(k, data[k] >= 0)
+        sbot.replicate.request(k, data[k] >= 0, -data[k])
       }
     })
   )


### PR DESCRIPTION
This PR passes a new `priority` argument to `replicate.request` so that replication can prioritise who to replicate first.

At the moment the priority value comes from the peer's hop distance. The fewer hops, the higher priority.

See [this PR](https://github.com/ssbc/ssb-ebt/pull/15) for how the priority is used.

