### PR TITLE
fix manifest 

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ but you might replicate them if your friend follows them.
 this comes built into scuttlebot by default, you are probably using this api by writing a client
 app or using sbot from a cli tool.
 
+> Note: synchronous methods called over a `ssb-client` connection are converted into asynchronous methods (a callback is added as the final argument which will be called back with the result)
+
 ### hopStream () => Source
 
 return a stream of hops objects `{<id>:<dist>,...}`, the first item is the current state,


### PR DESCRIPTION
PR TYPE : `patch` / courtesy

**Problem** : the API documented in the README is not active.

**Solution**: I have read the docs, and read what is being returned by init. Looking at the manifest there are things clearly missing. I've brought it into line with the intention read in these other two places.

 @dominictarr I'm going to publish this as a patch. What needs your eyes is making sure I marked all the methods appropriately as source / async / sync.