### PR TITLE
fix passing options to layered.getHops

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,7 +120,7 @@ exports.init = function (sbot, config) {
       layered.onReady(function () {
         if(isFunction(opts))
           cb = opts, opts = {}
-        cb(null, layered.getHops())
+        cb(null, layered.getHops(opts))
       })
     },
     // legacy


### PR DESCRIPTION
The existing code was ignoring options passed to `friends.hops`. This PR fixes it!

This addresses most of #17 for me.