### PR TITLE
add missing dep pull-notify

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "layered-graph": "^1.1.1",
     "pull-cont": "^0.1.1",
     "pull-flatmap": "0.0.1",
+    "pull-notify": "^0.1.1",
     "pull-stream": "^3.6.0",
     "ssb-ref": "^2.7.1"
   },


### PR DESCRIPTION
pull-notify is used in this library but was not in package.json https://github.com/ssbc/ssb-friends/blob/2022fd5466e89a3a3422767725dca39b4864be3d/legacy.js#L3