### PR TITLE
fix race condition on friends.stream - fixes#37

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 'use strict'
 var LayeredGraph = require('layered-graph')
 var pull         = require('pull-stream')
-var pCont        = require('pull-cont/source')
 var isFeed       = require('ssb-ref').isFeed
 // friends plugin
 // methods to analyze the social graph

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   "dependencies": {
     "flumeview-reduce": "^1.3.0",
     "layered-graph": "^1.1.1",
-    "pull-cont": "^0.1.1",
     "pull-flatmap": "0.0.1",
     "pull-notify": "^0.1.1",
     "pull-stream": "^3.6.0",


### PR DESCRIPTION
I was experiencing a bad problem with a legacy API. (https://github.com/ssbc/ssb-friends/issues/37)
The problem this fixes is patchbay sometimes not knowing at all what any of your relationships are. It's a security problem because you can't check if you have an existing relationship with a person.

This is a poor fix. I would like to move beyond this API and access the layered graph more directly to answer some of the questions I need `ssb-friends` to answer. I'm genuinely excited about that, and it's a dedicated piece of work seperate to this. 

cc @dominictarr 
