### PR TITLE
pause a tick before checking + using sbot.replicate

### DIFF
--- a/contacts.js
+++ b/contacts.js
@@ -1,6 +1,6 @@
 var Reduce = require('flumeview-reduce')
 var isFeed = require('ssb-ref').isFeed
-//track contact messages, follow, unfollow, block
+// track contact messages, follow, unfollow, block
 
 module.exports = function (sbot, createLayer, config) {
   var layer = createLayer('contacts')
@@ -10,17 +10,17 @@ module.exports = function (sbot, createLayer, config) {
 
   const INDEX_VERSION = 10
   var index = sbot._flumeUse('contacts2', Reduce(INDEX_VERSION, function (g, data) {
-    if(!g) g = {}
+    if (!g) g = {}
 
     var from = data.value.author
     var to = data.value.content.contact
     var value =
-      data.value.content.blocking || data.value.content.flagged ? -1 :
-      data.value.content.following === true ? 1
-      : -2
+      data.value.content.blocking || data.value.content.flagged ? -1
+        : data.value.content.following === true ? 1
+          : -2
 
-    if(isFeed(from) && isFeed(to)) {
-      if(initial) {
+    if (isFeed(from) && isFeed(to)) {
+      if (initial) {
         layer(from, to, value)
       }
       g[from] = g[from] || {}
@@ -32,10 +32,8 @@ module.exports = function (sbot, createLayer, config) {
   // trigger flume machinery to wait until index is ready,
   // otherwise there is a race condition when rebuilding the graph.
   index.get(function (err, g) {
+    if (err) throw err
     initial = true
     layer(g || {})
   })
 }
-
-
-

--- a/index.js
+++ b/index.js
@@ -24,10 +24,8 @@ exports.manifest = {
   stream: 'source'              // legacy
 }
 
-//mdm.manifest(apidoc)
-
 exports.init = function (sbot, config) {
-  var max = config.friends && config.friends.hops || config.replicate && config.replicate.hops || 3
+  var max = (config.friends && config.friends.hops) || (config.replicate && config.replicate.hops) || 3
   var layered = LayeredGraph({max: max, start: sbot.id})
 
   function isFollowing (opts, cb) {
@@ -54,26 +52,28 @@ exports.init = function (sbot, config) {
     })
   })
 
-  if(!sbot.replicate)
-    throw new Error('ssb-friends expects a replicate plugin to be available')
-
-  // opinion: replicate with everyone within max hops (max passed to layered above ^)
-  pull(
-    layered.hopStream({live: true, old: true}),
-    pull.drain(function (data) {
-      if(data.sync) return
-      for(var k in data) {
-        sbot.replicate.request(k, data[k] >= 0)
-      }
-    })
-  )
-
   contacts(sbot, layered.createLayer, config)
 
   var legacy = _legacy(layered)
 
-  //opinion: pass the blocks to replicate.block
+  // check for ssb-replicate or similar, but with a delay so other plugins have time to be loaded
   setImmediate(function () {
+    if (!sbot.replicate) {
+      throw new Error('ssb-friends expects a replicate plugin to be available')
+    }
+
+    // opinion: replicate with everyone within max hops (max passed to layered above ^)
+    pull(
+      layered.hopStream({live: true, old: true}),
+      pull.drain(function (data) {
+        if(data.sync) return
+        for(var k in data) {
+          sbot.replicate.request(k, data[k] >= 0)
+        }
+      })
+    )
+
+    //opinion: pass the blocks to replicate.block
     var block = (sbot.replicate && sbot.replicate.block) || (sbot.ebt && sbot.ebt.block)
     if(block) {
       function handleBlockUnlock(from, to, value) {

--- a/legacy.js
+++ b/legacy.js
@@ -95,14 +95,3 @@ module.exports = function (layered) {
     }
   }
 }
-
-function isEmpty (obj) {
-  return typeof obj === 'object' &&
-    Object.keys(obj).length === 0
-}
-
-
-
-
-
-

--- a/test/sbot.js
+++ b/test/sbot.js
@@ -85,4 +85,25 @@ tape('live follows works', function (t) {
   })
 })
 
+tape('chill plugin order', t => {
+  var createSbot = require('secret-stack')({
+    caps: {shs: crypto.randomBytes(32).toString('base64')}
+  })
+    .use(require('ssb-db'))
+    .use(require('..'))
+    .use(require('ssb-replicate'))
 
+  var bot = createSbot({
+    temp: 'plugin-order',
+    port: 45457,
+    host: 'localhost',
+    timeout: 20001,
+    replicate: {
+      hops: 100,
+      legacy: false
+    }
+  })
+
+  t.true(bot, 'loads plugins in whatever order fine')
+  bot.close(t.end)
+})


### PR DESCRIPTION
The problem is that loading ssb-friends + ssb-replicate, if you load them in the wrong order
then ssb-friends throws an error.
This PR chills it out just a little, enough that this false error should not be thrown
at unsuspecting developers