### PR TITLE
Update db2 dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "git://github.com/ssbc/ssb-friends.git"
   },
   "dependencies": {
-    "bipf": "^1.4.0",
+    "bipf": "^1.5.0",
     "flumecodec": "0.0.1",
     "flumeview-reduce": "^1.3.17",
     "layered-graph": "^1.1.1",
@@ -20,7 +20,7 @@
     "pull-level": "^2.0.4",
     "pull-notify": "^0.1.1",
     "pull-stream": "^3.6.0",
-    "ssb-db2": "^1.14.0",
+    "ssb-db2": "^2.0.0",
     "ssb-ref": "^2.7.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This turned out to be easier than expected. As this module just adds an [index](https://github.com/ssbc/ssb-friends/blob/master/db2-contacts.js) to db2 it is not affected by the breaking change in db2 2.0.