### PR TITLE
replace continuables with async-await

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "nyc": "^15.1.0",
-    "run-series": "^1.1.8",
+    "promisify-tuple": "^1.2.0",
     "scuttle-testbot": "^1.3.0",
     "secret-stack": "^6.1.2",
     "ssb-caps": "^1.1.0",

--- a/test/contact-messages.js
+++ b/test/contact-messages.js
@@ -1,101 +1,96 @@
 const tape = require('tape')
+const run = require('promisify-tuple')
 const u = require('./util')
 
 const feedId = '@th3J6gjmDOBt77SRX1EFFWY0aH2Wagn21iUZViZFFxk=.ed25519'
 
-tape('follow', t => {
+tape('friends.follow()', async t => {
   const sbot = u.Server({ tribes: true })
 
   /* FOLLOW */
-  sbot.friends.follow(feedId, {}, (err, msg) => {
-    if (err) throw err
+  const [err1, msg1] = await run(sbot.friends.follow)(feedId, {})
+  t.error(err1)
 
-    // NOTE get here just to confirm recps: undefined not present
-    sbot.get(msg.key, (_, value) => {
-      t.deepEqual(
-        value.content,
-        {
-          type: 'contact',
-          contact: feedId,
-          following: true
-        },
-        'publishes a follow message!'
-      )
+  // NOTE get here just to confirm recps: undefined not present
+  const [err2, value] = await run(sbot.get)(msg1.key)
+  t.error(err2)
+  t.deepEqual(
+    value.content,
+    {
+      type: 'contact',
+      contact: feedId,
+      following: true
+    },
+    'publishes a follow message!'
+  )
 
-      /* UNFOLLOW */
-      sbot.friends.follow(feedId, { state: false }, (err, msg) => {
-        if (err) throw err
+  /* UNFOLLOW */
+  const [err3, msg3] = await run(sbot.friends.follow)(feedId, { state: false })
+  t.error(err3)
+  t.deepEqual(
+    msg3.value.content,
+    {
+      type: 'contact',
+      contact: feedId,
+      following: false,
+      recps: undefined
+    },
+    'publishes a unfollow message!'
+  )
 
-        t.deepEqual(
-          msg.value.content,
-          {
-            type: 'contact',
-            contact: feedId,
-            following: false,
-            recps: undefined
-          },
-          'publishes a unfollow message!'
-        )
+  /* PRIVATE FOLLOW */
+  const [err4, msg4] = await run(sbot.friends.follow)(feedId, { recps: [sbot.id] })
+  t.error(err4)
+  t.match(msg4.value.content, /box\d$/, 'publishes a private follow')
 
-        /* PRIVATE FOLLOW */
-        sbot.friends.follow(feedId, { recps: [sbot.id] }, (err, msg) => {
-          if (err) throw err
-          t.match(msg.value.content, /box\d$/, 'publishes a private follow')
-
-          sbot.close(t.end)
-        })
-      })
-    })
-  })
+  await run(sbot.close)()
+  t.end()
 })
 
-tape('block', t => {
+tape('friends.block()', async t => {
   const sbot = u.Server({ tribes: true })
 
   /* BLOCK */
-  sbot.friends.block(feedId, {}, (err, msg) => {
-    if (err) throw err
+  const [err1, msg1] = await run(sbot.friends.block)(feedId, {})
+  t.error(err1)
 
-    // NOTE get here just to confirm recps: undefined not present
-    sbot.get(msg.key, (_, value) => {
-      t.deepEqual(
-        value.content,
-        {
-          type: 'contact',
-          contact: feedId,
-          blocking: true
-        },
-        'publishes a block message!'
-      )
+  // NOTE get here just to confirm recps: undefined not present
+  const [err2, value] = await run(sbot.get)(msg1.key)
+  t.error(err2)
+  t.deepEqual(
+    value.content,
+    {
+      type: 'contact',
+      contact: feedId,
+      blocking: true
+    },
+    'publishes a block message!'
+  )
 
-      /* UNBLOCK */
-      const opts = {
-        state: false,
-        reason: 'we talked in person'
-      }
-      sbot.friends.block(feedId, opts, (err, msg) => {
-        if (err) throw err
+  /* UNBLOCK */
+  const opts = {
+    state: false,
+    reason: 'we talked in person'
+  }
+  const [err3, msg3] = await run(sbot.friends.block)(feedId, opts)
+  t.error(err3)
+  t.deepEqual(
+    msg3.value.content,
+    {
+      type: 'contact',
+      contact: feedId,
+      blocking: false,
+      reason: 'we talked in person',
+      recps: undefined
+    },
+    'publishes an unblock message!'
+  )
 
-        t.deepEqual(
-          msg.value.content,
-          {
-            type: 'contact',
-            contact: feedId,
-            blocking: false,
-            reason: 'we talked in person',
-            recps: undefined
-          },
-          'publishes an unblock message!'
-        )
+  /* PRIVATE BLOCK */
+  const [err4, msg4] = await run(sbot.friends.block)(feedId, { recps: [sbot.id] })
+  t.error(err4)
+  t.match(msg4.value.content, /box\d$/, 'publishes a private block')
 
-        /* PRIVATE BLOCK */
-        sbot.friends.block(feedId, { recps: [sbot.id] }, (err, msg) => {
-          if (err) throw err
-          t.match(msg.value.content, /box\d$/, 'publishes a private block')
-
-          sbot.close(t.end)
-        })
-      })
-    })
-  })
+  await run(sbot.close)()
+  t.end()
 })

--- a/test/hops.js
+++ b/test/hops.js
@@ -1,6 +1,6 @@
 const tape = require('tape')
 const pull = require('pull-stream')
-const series = require('run-series')
+const run = require('promisify-tuple')
 const u = require('./util')
 
 const botA = u.Server({
@@ -10,7 +10,7 @@ const botA = u.Server({
   }
 })
 
-tape('friends are re-emitted when distance changes when `hops: 2`', (t) => {
+tape('friends are re-emitted when distance changes `hops: 2`', async (t) => {
   const changes = []
   const hops = {}
 
@@ -34,282 +34,204 @@ tape('friends are re-emitted when distance changes when `hops: 2`', (t) => {
   const feedB = botA.createFeed()
   const feedC = botA.createFeed()
 
-  series([
-    // feedA -> feedB
-    cb => {
-      feedA.publish({
-        type: 'contact',
-        contact: feedB.id,
-        following: true
-      }, cb)
+  // feedA -> feedB
+  await run(feedA.publish)({
+    type: 'contact',
+    contact: feedB.id,
+    following: true
+  })
+  t.deepEqual(changes, [ { id: botA.id, hops: 0 } ])
+  changes.length = 0
+
+  // feedB -> feedC
+  await run(feedB.publish)({
+    type: 'contact',
+    contact: feedC.id,
+    following: true
+  })
+
+  // follow feedA
+  await run(botA.publish)({
+    type: 'contact',
+    contact: feedA.id,
+    following: true
+  })
+  t.deepEqual(changes, [
+    { id: feedA.id, hops: 1 },
+    { id: feedB.id, hops: 2 }
+  ])
+  changes.length = 0
+
+  // follow feedB
+  await run(botA.publish)({
+    type: 'contact',
+    contact: feedB.id,
+    following: true
+  })
+  t.deepEqual(changes, [
+    { id: feedB.id, hops: 1 },
+    { id: feedC.id, hops: 2 }
+  ])
+
+  const [err, g] = await run(botA.friends.get)()
+  t.error(err)
+  t.deepEqual(g, {
+    [feedA.id]: {
+      [feedB.id]: true
     },
-    cb => {
-      t.deepEqual(changes, [
-        { id: botA.id, hops: 0 }
-      ])
-
-      changes.length = 0
-
-      // feedB -> feedC
-      feedB.publish({
-        type: 'contact',
-        contact: feedC.id,
-        following: true
-      }, cb)
+    [feedB.id]: {
+      [feedC.id]: true
     },
-    cb => {
-      // follow feedA
-      botA.publish({
-        type: 'contact',
-        contact: feedA.id,
-        following: true
-      }, cb)
-    },
-    cb => {
-      t.deepEqual(changes, [
-        { id: feedA.id, hops: 1 },
-        { id: feedB.id, hops: 2 }
-      ])
-
-      changes.length = 0
-
-      // follow feedB
-      botA.publish({
-        type: 'contact',
-        contact: feedB.id,
-        following: true
-      }, cb)
-    },
-    cb => {
-      t.deepEqual(changes, [
-        { id: feedB.id, hops: 1 },
-        { id: feedC.id, hops: 2 }
-      ])
-
-      const G = {}
-
-      series([
-        cb => {
-          botA.friends.get(function (err, g) {
-            t.error(err)
-
-            G[feedA.id] = {}
-            G[feedA.id][feedB.id] = true
-            G[feedB.id] = {}
-            G[feedB.id][feedC.id] = true
-            G[botA.id] = {}
-            G[botA.id][feedA.id] = true
-            G[botA.id][feedB.id] = true
-            t.deepEqual(g, G)
-
-            cb()
-          })
-        },
-        cb => {
-          botA.friends.get({
-            source: botA.id
-          }, function (err, g) {
-            t.error(err)
-            t.deepEqual(g, G[botA.id])
-            cb()
-          })
-        }
-      ], cb)
-    },
-    cb => {
-      botA.friends.get({
-        dest: feedB.id
-      }, function (err, g) {
-        t.error(err)
-
-        const _c = {}
-        _c[feedA.id] = true
-        _c[botA.id] = true
-
-        t.deepEqual(g, _c)
-
-        cb()
-      })
-    },
-    cb => {
-      botA.friends.get({
-        source: botA.id,
-        dest: feedB.id
-      }, function (err, follows) {
-        t.error(err)
-        t.equal(follows, true)
-        cb()
-      })
-    },
-    cb => {
-      botA.friends.get({
-        source: botA.id,
-        dest: feedC.id
-      }, function (err, follows) {
-        t.error(err)
-        t.notOk(follows)
-        cb()
-      })
+    [botA.id]: {
+      [feedA.id]: true,
+      [feedB.id]: true
     }
-  ], t.end)
+  })
+
+  const [err2, g2] = await run(botA.friends.get)({ source: botA.id })
+  t.error(err2)
+  t.deepEqual(g2, {
+    [feedA.id]: true,
+    [feedB.id]: true
+  })
+
+  const [err3, g3] = await run(botA.friends.get)({ dest: feedB.id })
+  t.error(err3)
+  t.deepEqual(g3, {
+    [feedA.id]: true,
+    [botA.id]: true
+  })
+
+  const [err4, follows] = await run(botA.friends.get)({ source: botA.id, dest: feedB.id })
+  t.error(err4)
+  t.equal(follows, true)
+
+  const [err5, follows5] = await run(botA.friends.get)({ source: botA.id, dest: feedC.id })
+  t.error(err5)
+  t.notOk(follows5)
+
+  t.end()
 })
 
-tape('legacy blocking / unblocking works', (t) => {
+tape('legacy blocking / unblocking works', async (t) => {
   const feedD = botA.createFeed()
   const feedE = botA.createFeed()
 
-  series([
-    cb => {
-      feedD.publish({
-        type: 'contact',
-        contact: feedE.id,
-        following: true
-      }, cb)
-    },
-    cb => {
-      botA.friends.get({
-        source: feedD.id,
-        dest: feedE.id
-      }, function (err, follows) {
-        t.error(err)
-        t.equal(follows, true)
-        cb()
-      })
-    },
-    cb => {
-      feedD.publish({
-        type: 'contact',
-        contact: feedE.id,
-        blocking: true
-      }, cb)
-    },
-    cb => {
-      botA.friends.get({
-        source: feedD.id,
-        dest: feedE.id
-      }, function (err, follows) {
-        t.error(err)
-        t.notOk(follows)
-        cb()
-      })
-    },
-    cb => {
-      feedD.publish({
-        type: 'contact',
-        contact: feedE.id,
-        blocking: false
-      }, cb)
-    },
-    cb => {
-      botA.friends.get({
-        source: feedD.id,
-        dest: feedE.id
-      }, function (err, follows) {
-        t.error(err)
-        // should not go back to following, after unblocking
-        t.notOk(follows)
-        cb()
-      })
-    }
-  ], t.end)
+  await run(feedD.publish)({
+    type: 'contact',
+    contact: feedE.id,
+    following: true
+  })
+
+  const [err1, follows1] = await run(botA.friends.get)({
+    source: feedD.id,
+    dest: feedE.id
+  })
+  t.error(err1)
+  t.equal(follows1, true)
+
+  await run(feedD.publish)({
+    type: 'contact',
+    contact: feedE.id,
+    blocking: true
+  })
+
+  const [err2, follows2] = await run(botA.friends.get)({
+    source: feedD.id,
+    dest: feedE.id
+  })
+  t.error(err2)
+  t.notOk(follows2)
+
+  await run(feedD.publish)({
+    type: 'contact',
+    contact: feedE.id,
+    blocking: false
+  })
+
+  const [err3, follows3] = await run(botA.friends.get)({
+    source: feedD.id,
+    dest: feedE.id
+  })
+  t.error(err3)
+  // should not go back to following, after unblocking
+  t.notOk(follows3)
+
+  t.end()
 })
 
-tape('hops blocking / unblocking works', function (t) {
+tape('hops blocking / unblocking works', async (t) => {
   const feedF = botA.createFeed()
-  series([
-    cb => {
-      botA.publish({
-        type: 'contact',
-        contact: feedF.id,
-        blocking: true
-      }, cb)
-    },
-    cb => {
-      botA.friends.hops(function (err, hops) {
-        t.error(err)
-        t.equal(hops[feedF.id], -1)
-        cb()
-      })
-    },
-    cb => {
-      botA.publish({
-        type: 'contact',
-        contact: feedF.id,
-        blocking: false
-      }, cb)
-    },
-    cb => {
-      botA.friends.hops(function (err, hops) {
-        t.error(err)
-        t.equal(hops[feedF.id], -2)
-        cb()
-      })
-    }
-  ], t.end)
+
+  await run(botA.publish)({
+    type: 'contact',
+    contact: feedF.id,
+    blocking: true
+  })
+
+  const [err, hops] = await run(botA.friends.hops)()
+  t.error(err)
+  t.equal(hops[feedF.id], -1)
+
+  await run(botA.publish)({
+    type: 'contact',
+    contact: feedF.id,
+    blocking: false
+  })
+
+  const [err2, hops2] = await run(botA.friends.hops)()
+  t.error(err2)
+  t.equal(hops2[feedF.id], -2)
+
+  t.end()
 })
 
-tape('hops blocking / unblocking works', function (t) {
+tape('hops blocking / unblocking works', async (t) => {
   const feedH = botA.createFeed()
   const feedI = botA.createFeed()
-  series([
-    cb => {
-      botA.publish({
-        type: 'contact',
-        contact: feedH.id,
-        following: true
-      }, cb)
-    },
-    cb => {
-      feedH.publish({
-        type: 'contact',
-        contact: feedI.id,
-        following: true
-      }, cb)
-    },
-    cb => {
-      botA.friends.hops(function (err, hops) {
-        t.error(err)
-        t.equal(hops[feedH.id], 1)
-        t.equal(hops[feedI.id], 2)
-        cb()
-      })
-    },
-    cb => {
-      botA.publish({
-        type: 'contact',
-        contact: feedI.id,
-        blocking: true
-      }, cb)
-    },
-    cb => {
-      botA.friends.hops(function (err, hops) {
-        t.error(err)
-        t.equal(hops[feedH.id], 1)
-        t.equal(hops[feedI.id], -1)
-        cb()
-      })
-    },
-    // after unblocking, goes back to 2,
-    // because H follows.
-    cb => {
-      botA.publish({
-        type: 'contact',
-        contact: feedI.id,
-        blocking: false
-      }, cb)
-    },
-    cb => {
-      botA.friends.hops(function (err, hops) {
-        t.error(err)
-        t.equal(hops[feedH.id], 1)
-        t.equal(hops[feedI.id], 2)
-        cb()
-      })
-    }
-  ], t.end)
+
+  await run(botA.publish)({
+    type: 'contact',
+    contact: feedH.id,
+    following: true
+  })
+
+  await run(feedH.publish)({
+    type: 'contact',
+    contact: feedI.id,
+    following: true
+  })
+
+  const [err, hops] = await run(botA.friends.hops)()
+  t.error(err)
+  t.equal(hops[feedH.id], 1)
+  t.equal(hops[feedI.id], 2)
+
+  await run(botA.publish)({
+    type: 'contact',
+    contact: feedI.id,
+    blocking: true
+  })
+
+  const [err2, hops2] = await run(botA.friends.hops)()
+  t.error(err2)
+  t.equal(hops2[feedH.id], 1)
+  t.equal(hops2[feedI.id], -1)
+
+  await run(botA.publish)({
+    type: 'contact',
+    contact: feedI.id,
+    blocking: false
+  })
+
+  const [err3, hops3] = await run(botA.friends.hops)()
+  t.error(err3)
+  t.equal(hops3[feedH.id], 1)
+  t.equal(hops3[feedI.id], 2)
+
+  t.end()
 })
 
 tape('finish tests', (t) => {
-  botA.close()
-  t.end()
+  botA.close(t.end)
 })


### PR DESCRIPTION
Some context from Cabal chats:

> **staltz**
> assuming this is a JS channel too: I want to eliminate continuables and replace them with async-await
>
> example: https://github.com/ssbc/ssb-friends/blob/ee6df464f3e1814a7b68f543317e0bb0a8e61d3d/test/friends.js#L38https://github.com/ssbc/ssb-friends/blob/ee6df464f3e1814a7b68f543317e0bb0a8e61d3d/test/friends.js#L38
>
> continuables are a beautifully sound way of doing async in JS: https://github.com/Raynos/continuable 
>
> but in the name of reducing the amount of WTF the generic programmer will have when reading SSB code, we should use the least surprising async primitive there is out there, and that's async-await
>
> also, continuables are a 8-year old idea that didn't catch on
>
> **glyph**
> big +1 from me. more generic, more better (taking into account other trade-offs, of course)