### PR TITLE
fix glue/replicate logic

### DIFF
--- a/glue/replicate.js
+++ b/glue/replicate.js
@@ -12,6 +12,8 @@ module.exports = function replicationGlue(sbot, layered, legacy) {
       if (dest !== sbot.id) sbot.replicate.block(orig, dest, value === false)
     }
 
+    sbot.replicate.request(sbot.id, true)
+
     pull(
       legacy.stream({ live: true }),
       pull.filter(contacts => !!contacts),

--- a/glue/replicate.js
+++ b/glue/replicate.js
@@ -1,25 +1,29 @@
 const pull = require('pull-stream')
 
-module.exports = function replicationGlue(sbot, layered) {
+module.exports = function replicationGlue(sbot, layered, legacy) {
   // check for ssb-replicate or similar, but with a delay so other plugins have time to be loaded
   setImmediate(() => {
     if (!sbot.replicate) {
       throw new Error('ssb-friends expects a replicate plugin to be available')
     }
 
-    const request = (sbot.replicate.request)
-    const block = (sbot.replicate.block) || (sbot.ebt && sbot.ebt.block)
+    function updateEdge(orig, dest, value) {
+      if (orig === sbot.id) sbot.replicate.request(dest, !!value)
+      if (dest !== sbot.id) sbot.replicate.block(orig, dest, value === false)
+    }
 
-    // opinion: replicate with everyone within max hops (max passed to layered above ^)
     pull(
-      layered.hopStream({ live: true, old: true }),
-      pull.drain((hopsData) => {
-        if (hopsData.sync) return
-        for (const feedId of Object.keys(hopsData)) {
-          const val = hopsData[feedId]
-          if (val >= 0) request(feedId, true)
-          if (val === -1) block(sbot.id, feedId, true)
-          if (val === -2) block(sbot.id, feedId, false)
+      legacy.stream({ live: true }),
+      pull.filter(contacts => !!contacts),
+      pull.drain((contacts) => {
+        if (contacts.from && contacts.to) {
+          updateEdge(contacts.from, contacts.to, contacts.value)
+        } else {
+          for (const from of Object.keys(contacts)) {
+            for (const to of Object.keys(contacts[from])) {
+              updateEdge(from, to, contacts[from][to])
+            }
+          }
         }
       })
     )

--- a/glue/replicate.js
+++ b/glue/replicate.js
@@ -9,7 +9,7 @@ module.exports = function replicationGlue(sbot, layered, legacy) {
 
     function updateEdge(orig, dest, value) {
       if (orig === sbot.id) sbot.replicate.request(dest, value !== false)
-      if (dest !== sbot.id) sbot.replicate.block(orig, dest, !value)
+      if (dest !== sbot.id) sbot.replicate.block(orig, dest, value === false)
     }
 
     sbot.replicate.request(sbot.id, true)

--- a/glue/replicate.js
+++ b/glue/replicate.js
@@ -8,14 +8,14 @@ module.exports = function replicationGlue(sbot, layered, legacy) {
     }
 
     function updateEdge(orig, dest, value) {
-      if (orig === sbot.id) sbot.replicate.request(dest, !!value)
-      if (dest !== sbot.id) sbot.replicate.block(orig, dest, value === false)
+      if (orig === sbot.id) sbot.replicate.request(dest, value !== false)
+      if (dest !== sbot.id) sbot.replicate.block(orig, dest, !value)
     }
 
     sbot.replicate.request(sbot.id, true)
 
     pull(
-      legacy.stream({ live: true }),
+      legacy.stream(),
       pull.filter(contacts => !!contacts),
       pull.drain((contacts) => {
         if (contacts.from && contacts.to) {

--- a/index.js
+++ b/index.js
@@ -106,7 +106,7 @@ exports.init = function (sbot, config) {
     authGlue(sbot, isBlocking)
 
   if (config.friends.hookReplicate !== false) // defaults to true
-    replicationGlue(sbot, layered)
+    replicationGlue(sbot, layered, legacy)
 
   return {
     hopStream: layered.hopStream,


### PR DESCRIPTION
TL;DR: `layered.hopsStream` gives us "reduced" data of the follow graph from the perspective of the `sbot.id` peer, but `legacy.stream` gives us "non-reduced" updates on the individual edges of the follow graph, from the perspective of the edge outgoing peer.

This was important because we have to call `sbot.replicate.block(orig, dest, ...)` even if `orig !== sbot.id` and `dest !== sbot.id`. Currently, there is no non-legacy API that provides us this kind of information, so that's why I had to use `legacy.stream`.

This change is very important to fix the tests in ssb-ebt (I tried it out, tests pass).

Eventually, the legacy API will be deleted and I'll make another suitable API, and this file glue/replicate.js will also be deleted. But for now, I just want to get tests in a good shape so that we are confident to make modifications.