### PR TITLE
test that private follows are in the social graph

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,12 +28,15 @@
     "ssb-ref": "^2.13.0"
   },
   "devDependencies": {
+    "mkdirp": "^1.0.4",
     "nyc": "^15.1.0",
     "promisify-tuple": "^1.2.0",
+    "rimraf": "^3.0.2",
     "scuttle-testbot": "^1.6.0",
     "secret-stack": "^6.4.0",
     "ssb-caps": "^1.1.0",
     "ssb-generate": "^1.0.1",
+    "ssb-keys": "^8.2.0",
     "ssb-tribes": "^0.4.1",
     "standard": "^16.0.2",
     "tap-spec": "^5.0.0",

--- a/test/privately-db2.js
+++ b/test/privately-db2.js
@@ -1,0 +1,98 @@
+const tape = require('tape')
+const os = require('os')
+const path = require('path')
+const run = require('promisify-tuple')
+const ssbKeys = require('ssb-keys')
+const SecretStack = require('secret-stack')
+const caps = require('ssb-caps')
+const rimraf = require('rimraf')
+const mkdirp = require('mkdirp')
+
+const dir = path.join(os.tmpdir(), 'friends-db2')
+
+function Server(opts = {}) {
+  const stack = SecretStack({caps})
+    .use(require('ssb-db2'))
+    .use(require('ssb-db2/compat'))
+    .use(require('..'))
+
+  return stack(opts)
+}
+
+tape('follow() and isFollowing() privately in ssb-db2', async (t) => {
+  rimraf.sync(dir)
+  mkdirp.sync(dir)
+  const sbot = Server({
+    keys: ssbKeys.generate(),
+    db2: true,
+    friends: {
+      hookAuth: false,
+    },
+    path: dir,
+  })
+
+  const source = sbot.id
+  const dest = '@th3J6gjmDOBt77SRX1EFFWY0aH2Wagn21iUZViZFFxk=.ed25519'
+
+  const [err1, response1] = await run(sbot.friends.isFollowing)({
+    source,
+    dest,
+  })
+  t.error(err1, 'no error')
+  t.false(response1, 'not following')
+
+  const [err2, msg2] = await run(sbot.friends.follow)(dest, {
+    recps: [source],
+  })
+  t.error(err2, 'no error')
+  t.match(msg2.value.content, /box$/, 'publishes a private follow')
+
+  const [err3, response3] = await run(sbot.friends.isFollowing)({
+    source,
+    dest,
+  })
+  t.error(err3, 'no error')
+  t.true(response3, 'following')
+
+  await run(sbot.close)()
+  t.end()
+})
+
+tape('block() and isBlocking() privately in ssb-db2', async (t) => {
+  rimraf.sync(dir)
+  mkdirp.sync(dir)
+  const sbot = Server({
+    keys: ssbKeys.generate(),
+    db2: true,
+    friends: {
+      hookAuth: false,
+    },
+    path: dir,
+  })
+
+  const source = sbot.id
+  const dest = '@th3J6gjmDOBt77SRX1EFFWY0aH2Wagn21iUZViZFFxk=.ed25519'
+
+  const [err1, response1] = await run(sbot.friends.isBlocking)({
+    source,
+    dest,
+  })
+  t.error(err1, 'no error')
+  t.false(response1, 'not blocking')
+
+  const [err2, msg2] = await run(sbot.friends.block)(dest, {
+    recps: [source],
+  })
+  t.error(err2, 'no error')
+  t.match(msg2.value.content, /box$/, 'publishes a private block')
+
+  const [err3, response3] = await run(sbot.friends.isBlocking)({
+    source,
+    dest,
+  })
+  t.error(err3, 'no error')
+  t.true(response3, 'blocking')
+
+  await run(sbot.close)()
+  t.end()
+})

--- a/test/privately.js
+++ b/test/privately.js
@@ -1,0 +1,63 @@
+const tape = require('tape')
+const run = require('promisify-tuple')
+const u = require('./util')
+
+tape('follow() and isFollowing() privately', async (t) => {
+  const sbot = u.Server({tribes: true})
+
+  const source = sbot.id
+  const dest = '@th3J6gjmDOBt77SRX1EFFWY0aH2Wagn21iUZViZFFxk=.ed25519'
+
+  const [err1, response1] = await run(sbot.friends.isFollowing)({
+    source,
+    dest,
+  })
+  t.error(err1, 'no error')
+  t.false(response1, 'not following')
+
+  const [err2, msg2] = await run(sbot.friends.follow)(dest, {
+    recps: [source],
+  })
+  t.error(err2, 'no error')
+  t.match(msg2.value.content, /box\d$/, 'publishes a private follow')
+
+  const [err3, response3] = await run(sbot.friends.isFollowing)({
+    source,
+    dest,
+  })
+  t.error(err3, 'no error')
+  t.true(response3, 'following')
+
+  await run(sbot.close)()
+  t.end()
+})
+
+tape('block() and isBlocking() privately', async (t) => {
+  const sbot = u.Server({tribes: true})
+
+  const source = sbot.id
+  const dest = '@th3J6gjmDOBt77SRX1EFFWY0aH2Wagn21iUZViZFFxk=.ed25519'
+
+  const [err1, response1] = await run(sbot.friends.isBlocking)({
+    source,
+    dest,
+  })
+  t.error(err1, 'no error')
+  t.false(response1, 'not blocking')
+
+  const [err2, msg2] = await run(sbot.friends.block)(dest, {
+    recps: [source],
+  })
+  t.error(err2, 'no error')
+  t.match(msg2.value.content, /box\d$/, 'publishes a private block')
+
+  const [err3, response3] = await run(sbot.friends.isBlocking)({
+    source,
+    dest,
+  })
+  t.error(err3, 'no error')
+  t.true(response3, 'blocking')
+
+  await run(sbot.close)()
+  t.end()
+})


### PR DESCRIPTION
Some good news. I wrote tests, and it turned out that my claim in #43 (quote below) is incorrect, because the tests pass

> Currently ssb-friends is blind to private blocks, and if other modules rely on isBlocking, then private blocks will slip through and the blocked authors appear in the UI, etc.

I might still implement the API proposed in https://github.com/ssbc/ssb-friends/issues/43#issuecomment-888294939 but this PR is currently useful because this part of ssb-friends was not tested before.