### PR TITLE
update ssb-db2 to 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,10 +24,11 @@
     "pull-notify": "^0.1.1",
     "pull-pushable": "^2.2.0",
     "pull-stream": "^3.6.0",
-    "ssb-db2": "^2.1.0",
+    "ssb-db2": "^3.0.0",
     "ssb-ref": "^2.13.0"
   },
   "devDependencies": {
+    "envelope-spec": "1.0.0",
     "mkdirp": "^1.0.4",
     "nyc": "^15.1.0",
     "promisify-tuple": "^1.2.0",


### PR DESCRIPTION
## Context

There are a bunch of modules (such as `ssb-friends`), which require `ssb-db2`. If I update my `ssb-db2` dependency to `3.0.0`, then all these other modules would still pull in `ssb-db2` at `2.x`, because of the `^` in `^2.1.0`.

## Problem and solution

Update ssb-db2 to 3.0.0 even though the breaking change does not affect ssb-friends in any way.

## Side comment 

I also pinned `envelope-spec` to 1.0.0 because apparently there was a breaking change from 1.0.0 to 1.1.0, where the `tfk.json` file was removed. Since `ssb-tribes@0.4.1` was importing `envelope-spec` as `^1.0.0`, I was getting an error `Error: Cannot find module 'envelope-spec/encoding/tfk.json'`.