### PR TITLE
allow using ssb-db2@4

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "pull-notify": "^0.1.1",
     "pull-pushable": "^2.2.0",
     "pull-stream": "^3.6.0",
-    "ssb-db2": "^3.4.1",
+    "ssb-db2": ">=3.4.1 <=4",
     "ssb-ref": "^2.13.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This semver version range says that any ssb-db2 version 3.x.x is accepted as long as it's >=3.4.1 **and** any ssb-db2 version 4.x.x is accepted too. See https://semver.npmjs.com/ to play with the version range syntax.

Helps against having duplicates of ssb-db2 installed in node_modules.

@arj03 After this is merged, I'll make similar commits to other modules like ssb-meta-feeds but pushing to master directly since these are boring PRs. 