### PR TITLE
implement reset() db2Contacts index

### DIFF
--- a/db2-contacts.js
+++ b/db2-contacts.js
@@ -54,6 +54,15 @@ module.exports = function db2Contacts (createLayer) {
       cb()
     }
 
+    reset() {
+      this.updatePublicLayer({})
+      this.updatePrivateLayer({})
+      this.feeds = []
+      this.feedsIndex = {}
+      this.edges = {}
+      this.batchKeys = {}
+    }
+
     isPrivateRecord (recBuffer) {
       const pMeta = bipf.seekKey2(recBuffer, 0, BIPF_META, 0)
       if (pMeta < 0) return false

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "pull-notify": "^0.1.1",
     "pull-pushable": "^2.2.0",
     "pull-stream": "^3.6.0",
-    "ssb-db2": ">=3.4.1 <=4",
+    "ssb-db2": ">=4.1.0",
     "ssb-ref": "^2.13.0"
   },
   "devDependencies": {


### PR DESCRIPTION
In ssb-db2@4.1.0, leveldb indexes can be reset after compaction, in which we should also reset in-memory data structures.

This PR resets in-memory data structures for ssb-friends.