### PR TITLE
update deps to avoid rsjs-validate

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,18 +21,20 @@
     "pull-level": "^2.0.4",
     "pull-notify": "^0.1.1",
     "pull-stream": "^3.6.0",
-    "ssb-db2": "^2.0.0",
-    "ssb-ref": "^2.7.1"
+    "ssb-db2": "^7.0.0",
+    "ssb-ref": "^2.16.0"
   },
   "devDependencies": {
     "nyc": "^15.1.0",
     "promisify-tuple": "^1.2.0",
-    "scuttle-testbot": "^1.3.0",
-    "secret-stack": "^6.1.2",
+    "scuttle-testbot": "^1.11.0",
+    "secret-stack": "^6.4.1",
+    "ssb-backlinks": "^2.1.1",
     "ssb-caps": "^1.1.0",
     "ssb-generate": "^1.0.1",
+    "ssb-query": "^2.4.5",
     "ssb-replicate": "^1.1.0",
-    "ssb-tribes": "^0.4.1",
+    "ssb-tribes": "^3.1.2",
     "standard": "^16.0.2",
     "tap-spec": "^5.0.0",
     "tape": "^4.10.0"

--- a/test/util.js
+++ b/test/util.js
@@ -2,12 +2,16 @@ const ref = require('ssb-ref')
 const Server = require('scuttle-testbot')
 
 exports.Server = function Testbot (opts = {}) {
-  let stack = Server
+  const stack = Server
     .use(require('ssb-replicate'))
     .use(require('..'))
 
-  if (opts.tribes === true)
-    stack = stack.use(require('ssb-tribes'))
+  if (opts.tribes === true) {
+    stack
+      .use(require('ssb-backlinks'))
+      .use(require('ssb-query'))
+      .use(require('ssb-tribes'))
+  }
 
   return stack(opts)
 }


### PR DESCRIPTION
I am using friends@4 , but was hitting problems with Node@18 and the leftover rsjs-validate deps.

SO planning a patch release of ssb-friends which just removes that.
Here's where this branch sits:

```git
* 09ce3cd (HEAD -> rm_rsjs, origin/rm_rsjs) update deps to avoid rsjs-validate
* 691d58c (tag: v4.4.7, origin/update_4, update_4) 4.4.7
```